### PR TITLE
docs: add structured source reading guides

### DIFF
--- a/reading_guides/README.md
+++ b/reading_guides/README.md
@@ -1,0 +1,18 @@
+# gocql 導讀索引
+
+本資料夾提供閱讀 gocql 原始碼時的導覽指南，依照元件與職責分成多份文件，方便逐步掌握整體架構。建議的閱讀順序如下：
+
+1. [Cluster 與 Session 生命週期](cluster_and_session.md)
+2. [連線與連線池管理](connection_management.md)
+3. [查詢與執行流程](query_execution.md)
+4. [拓撲、節點與中繼資料](metadata_and_topology.md)
+5. [節點選擇與策略模組](policies_and_routing.md)
+6. [Scylla 專屬擴充功能](scylla_and_extensions.md)
+7. [通訊協定與序列化層](protocol_and_serialization.md)
+
+每份文件都包含：
+- 該模組的功能與設計原則
+- 重要資料結構／流程如何在程式碼中協作
+- 建議閱讀程式碼的路徑與注意事項
+
+搭配索引閱讀，可快速掌握驅動程式主要構件與延伸功能的關聯性。

--- a/reading_guides/cluster_and_session.md
+++ b/reading_guides/cluster_and_session.md
@@ -1,0 +1,25 @@
+# Cluster 與 Session 生命週期
+
+## ClusterConfig 與預設設定
+`ClusterConfig` 是驅動程式的核心進入點，用來設定節點列表、逾時、壓縮、認證、連線池大小與預設一致性等參數；同時也能配置警示處理、重新連線與主機篩選策略。【F:cluster.go†L57-L240】`NewCluster` 提供對應的預設值，包含 11 秒的請求/連線逾時、雙連線池大小、Quorum 一致性以及預設的 `WarningsHandler`、記錄器與重新連線策略，作為讀程式碼時的基準設定。【F:cluster.go†L401-L441】建立 Session 前，`Validate` 會檢查輸入是否合規（例如 Host 列表、認證配置、重新連線策略），確保後續初始流程不會因基本錯誤而失敗。【F:cluster.go†L501-L520】建議閱讀時先確認專案是否使用 `NewCluster` 預設值或自訂設定，以掌握下游組件的運作條件。
+
+## Session 結構與觀察介面
+`Session` 負責整個生命週期的管理，內部維護預設一致性、分頁與預取參數、查詢與批次觀察者、連線觀察者、Frame 監控器、Ring 描述器、Prepared Statement LRU 等資訊，是多個子系統的集合點。【F:session.go†L45-L110】配置時若提供 `WarningsHandlerBuilder`，會在 Session 建立時產生對應的警示處理器，以便在查詢執行結束後集中處理伺服端回傳的 warning。【F:cluster.go†L149-L149】【F:session.go†L205-L208】預設的處理器會寫入 Session 的 logger，也可以改成自訂實作。【F:warning_handler.go†L3-L28】這些欄位說明了 Session 為何能提供觀察性功能：查詢、批次、連線的 Observer 介面都是從這裡注入的。
+
+## Session 建立流程與資源初始化
+`newSessionCommon` 會先驗證 Cluster 設定，建立 `context`、預設一致性、Prepared Statement LRU 等資源，確保後續流程失敗時能正確釋放。【F:session.go†L139-L160】`NewSession` 會同步建立 `ConnConfig`、`policyConnPool` 與 `queryExecutor`，並啟動 goroutine 執行 `Session.init` 完成非阻塞初始化，同時回傳 `readyCh` 供等待完成。【F:session.go†L161-L254】初始流程會解析主機清單、建立控制連線、根據 `system.peers` 更新 Host 清單並設定 Partitioners，再填滿各節點連線池；若 `ReconnectInterval` > 0，亦會啟動背景任務定期嘗試重連下線節點。【F:session.go†L256-L445】閱讀初始流程時，可以依序追蹤：`addrsToHosts` → `control.connect` → `hostSource.GetHostsFromSystem` → `pool.addHost` → `hostConnPool.fill`，藉此掌握每個環節的責任。
+
+## 控制連線與心跳
+`controlConn` 介面負責執行系統查詢、協調 schema agreement 與偵測協定版本。它在 `heartBeat` 迴圈中週期性送出 `OPTIONS` frame，若失敗則觸發 `reconnect` 重建控制連線。【F:control.go†L61-L144】`Session.AwaitSchemaAgreement` 透過控制連線等待 schema version 一致，配合 `MaxWaitSchemaAgreement` 逾時，確保拓撲或 schema 變更後再繼續查詢。【F:session.go†L448-L463】閱讀控制連線時，可先理解 `createControlConn` 如何建立 retry policy，再進一步跟進 `discoverProtocol` 與 `querySystem` 等實作。
+
+## 事件處理與拓撲更新
+Session 建立兩個 `eventDebouncer` 分別負責 schema 與節點事件，透過緩衝與定時 flush 避免大量事件造成壓力。【F:events.go†L33-L109】schema 事件會清除 metadata 快取並通知負載策略；節點事件則整合拓撲與狀態更新，再呼叫 `handleNodeConnected` / `handleNodeDown` 等邏輯更新連線池與策略狀態。【F:events.go†L120-L200】閱讀時可先看 debouncer 如何聚合 frame，再對應到 `Session` 中哪些欄位被更新，理解事件 → metadata → pool → policy 的資料流。
+
+## 可觀測性與追蹤
+Session 提供多層級觀察：
+- `QueryObserver`、`BatchObserver` 會在嘗試完成後收到延遲與節點資訊，可從 `Query.attempt`／`Batch.attempt` 看詳細內容。【F:session.go†L1315-L1333】【F:session.go†L2248-L2276】 
+- `ConnectObserver` 在連線建立與結束時回報，方便記錄連線握手花費。【F:conn.go†L287-L313】
+- `Tracer` 與 `TraceWriter` 透過控制連線查詢 `system_traces` 取得事件紀錄，適合除錯複雜查詢。【F:tracer.go†L10-L121】
+- `WarningHandler` 會在迭代器取得 frame 後被呼叫，集中處理伺服端警告。【F:conn.go†L1454-L1462】【F:warning_handler.go†L3-L22】
+
+閱讀時建議先確認需求是否依賴這些觀察點，再追蹤對應的欄位與回呼時機，便能理解如何在應用程式中掛載監控與追蹤邏輯。

--- a/reading_guides/connection_management.md
+++ b/reading_guides/connection_management.md
@@ -1,0 +1,16 @@
+# 連線與連線池管理
+
+## ConnConfig 與 TLS 設定
+`ConnConfig` 彙整了協定版本、讀寫逾時、Dialer/HostDialer、壓縮器與認證等細節，建立連線時會直接套用；其中 TLS 相關設定來自 `SslOptions`，支援從憑證路徑載入或整合既有的 `tls.Config`，並可開啟主機名稱驗證。【F:conn.go†L70-L214】`connConfig` 工廠會根據 Cluster 設定建立預設的 `ScyllaShardAwareDialer`，必要時套用使用者自訂的 Dialer 或 HostDialer。【F:connectionpool.go†L65-L103】閱讀時可先確認應用程式是否覆寫這些欄位，以理解後續握手流程的差異。
+
+## Conn 結構與握手流程
+`Conn` 結構封裝了底層 socket、讀寫緩衝、streams 產生器、呼叫表、壓縮器、認證器與主機資訊，同時保存 frame/stream 觀察者與超時設定，顯示每個連線同時處理多重請求的能力。【F:conn.go†L191-L360】`dialShard`／`dialWithoutObserver` 會透過 HostDialer 建立 TCP 連線、初始化 Reader/Writer、設定壓縮器與 streams，並保存 host 資訊；完成初始查詢與認證後會呼叫 `finalizeConnection` 將逾時改回營運值，並依 Session 設定啟用 tablets routing 支援。【F:conn.go†L296-L360】【F:conn.go†L259-L267】【F:session.go†L307-L334】想理解握手細節時，可從 `dialShard` 進入，依序觀察 dial、`writeStartupFrame`、`authenticateHandshake`、`registerWithSchema` 等私有方法。
+
+## 連線池與 hostConnPool
+`policyConnPool` 依據 Session 設定維護每個 Host 的連線池，`SetHosts` 會比對現有主機、建立或關閉 `hostConnPool`，並在背景填滿連線池，確保至少有一條連線可用。【F:connectionpool.go†L54-L170】`hostConnPool` 以 `ConnPicker` 管理實際連線集合，`fill` 會避免重複填補、並行建立多條連線；若建立失敗還會利用 Debouncer 緩衝重試，避免對宕機節點過度打擾。【F:connectionpool.go†L255-L496】`ConnPicker` 預設實作為循環挑選最空閒的連線，同時支援 shard-aware 建立連線所需的 NextShard 介面。【F:connpicker.go†L9-L139】閱讀時可以先看 `policyConnPool.SetHosts` 如何根據拓撲變化新增/刪除池，再進入 `hostConnPool.fill` 了解實際建立流程，最後看 `defaultConnPicker` 如何挑選連線。
+
+## 請求執行與 Streams 管理
+`Conn.executeQuery` 會根據 Query 是否需要 Prepare 決定送出 `EXECUTE` 或 `QUERY` frame；對於 Prepared Statement 會驗證參數數量、執行自訂 binding，並在成功後更新 routing metadata。它同時負責寫入 custom payload（例如 tablets 路由資訊）與在迭代器上附加 warnings，最後依照伺服端回應型別決定是否重試或回傳錯誤。【F:conn.go†L1454-L1652】批次執行則由 `Conn.executeBatch` 完成，會逐筆 Prepare 語句、序列化參數後送出 `BATCH` frame，並同樣在結束時觸發 warning 處理。【F:conn.go†L1703-L1780】可搭配 `Conn.AvailableStreams`、`Conn.Close` 等方法理解連線壽命與併發控制。【F:conn.go†L1662-L1701】閱讀這段程式碼能掌握 driver 如何交錯處理 prepare、execute 與錯誤回復。
+
+## 錯誤處理與重連互動
+當建立連線或填滿連線池失敗時，`hostConnPool.fillingStopped` 會記錄錯誤、依需求標記節點為 down，並在下一次事件觸發前等待隨機時間以避免雪崩式重試。【F:connectionpool.go†L437-L466】若 `ReconnectInterval` 有設定，Session 會定期呼叫 `pool.addHost` 嘗試把 down 節點重新加入，由連線池自行判斷是否可建立新連線。【F:session.go†L420-L490】了解這些互動有助於除錯：連線數歸零時是否會觸發節點下線？重新連線策略是否與 Session 背景協程互相配合？建議在閱讀 `hostConnPool.connect` 時關注 `ReconnectionPolicy` 的使用方式與 Net 錯誤分類，掌握重試條件。【F:connectionpool.go†L497-L520】 

--- a/reading_guides/metadata_and_topology.md
+++ b/reading_guides/metadata_and_topology.md
@@ -1,0 +1,19 @@
+# 拓撲、節點與中繼資料
+
+## HostInfo 與節點狀態
+`HostInfo` 封裝節點的連線位址、資料中心、rack、HostID、版本、分區器、shard aware port 等資訊，並以讀寫鎖保護欄位；同檔案也定義了 `cassVersion` 與節點狀態常數，提供版本比較與節點上/下線判斷。【F:host_source.go†L37-L200】閱讀 `HostInfo` 的 Getter/Setter 有助於理解 Session 如何在事件處理、連線池與拓撲策略間共享節點資訊。
+
+## HostSource 與節點管理
+`hostSource` 負責維護所有已知節點（以 HostID 與 IP 映射），提供查詢、加入、移除、標記狀態等功能；同時提供 `fetchHostInfoAndUpdate` 透過控制連線更新節點資料，並支援 AddressTranslator 與 Peer 資料驗證。【F:host_source.go†L201-L640】當 Session 透過事件接收到拓撲或狀態變動時，會呼叫這些方法更新內部狀態，因此閱讀 hostSource 能掌握節點生命周期如何被追蹤。
+
+## RingDescriber 與 system.peers 查詢
+`ringDescriber` 使用控制連線輪詢 `system.local` 與 `system.peers`，解析得到的資料後產生 `HostInfo` 列表與 Partitioners，並記錄前一次結果以供 fallback；同時維護 HostID 與 IP 的映射供事件處理快速查詢。【F:ring_describer.go†L11-L199】`GetHostsFromSystem`、`getClusterPeerInfo`、`getLocalHostInfo` 是理解節點探索流程的核心，建議沿著這三個函式閱讀如何從查詢結果轉換為 HostInfo。
+
+## MetadataDescriber 與 schema 快取
+`metadataDescriber` 將 schema metadata 與 tablets metadata 快取在 `Metadata` 結構中，提供 `getSchema`、`AddTablet`、`RemoveTabletsWithKeyspace/Table` 等方法；若 cache 未命中，會呼叫 `refreshSchema` 重新查詢 system tables。`refreshAllSchema` 會遍歷既有 keyspace，比對策略與 table 差異，必要時清除 tablets 快取，確保 schema 變動後的路由資訊一致。【F:metadata_scylla.go†L442-L567】閱讀時可留意 mutex 的使用方式與 tablets 快取的寫入/清除時機。
+
+## Token 與拓撲策略
+`tokenRing` 將 `HostInfo` 的 token 列表整理成排序後的 ring，並依分區器類型（Murmur3、Ordered、Random）解析 token。【F:token.go†L43-L199】`topology.go` 內的 `placementStrategy`（`simpleStrategy`、`networkTopology`）會根據 keyspace 的策略選擇副本，生成 `tokenRingReplicas` 映射，用於 TokenAware 策略挑選節點。【F:topology.go†L34-L181】理解這些結構可幫助追蹤 TokenAwareHostPolicy 如何選擇目標節點。
+
+## Tablets 路由資訊
+`tablets` 套件定義 `TabletInfo`、`TabletInfoList` 與相關建構/查詢方法，能夠維持排序列表、插入新 tablets、移除重疊區間並查詢特定 keyspace/table 的範圍。【F:tablets/tablets.go†L1-L195】`metadataDescriber` 會透過這些 API 快取 Scylla tablets，供 policies 或 query routing 使用，因此理解 tablets 資料結構有助於分析 Scylla 特有的路由邏輯。

--- a/reading_guides/policies_and_routing.md
+++ b/reading_guides/policies_and_routing.md
@@ -1,0 +1,16 @@
+# 節點選擇與策略模組
+
+## Copy-on-write Host 列表
+多數策略都依賴 `cowHostList` 儲存節點集合。這個結構透過 `atomic.Value` 搭配互斥鎖，在更新時複製陣列、在讀取時無鎖存取，避免頻繁加鎖影響挑選效能。【F:policies.go†L40-L113】瞭解這個基礎資料結構，有助於閱讀各策略如何維護本地與遠端節點列表。
+
+## HostSelectionPolicy 介面
+`HostSelectionPolicy` 定義 Session 初始化、Partitioner 設定、Keyspace 變更與 `Pick` 介面；返回的 `NextHost` 迭代器會在同一查詢的多次嘗試間序列使用，因此策略可以安全地使用內部狀態而不需額外同步。【F:policies.go†L352-L369】預設的 `RoundRobinHostPolicy` 僅依序遍歷 copy-on-write host list，適合無需考量 token 或拓撲的場景。【F:policies.go†L424-L462】閱讀時可先熟悉這個基準行為，再比較其他策略的額外邏輯。
+
+## TokenAwareHostPolicy
+`TokenAwareHostPolicy` 結合 fallback 策略與 token ring，依據 routing key 或 tablets 資訊挑選節點。初始化時會綁定 Session 的 metadata 查詢函式，Keyspace 變更或 Partitioners 更新時會重建 `clusterMeta` 內的 token ring 與 replicas 映射。【F:policies.go†L524-L667】`Pick` 會先嘗試從 tablets 路由或 token ring 找到 replicas，再依設定決定是否隨機洗牌、避開忙碌節點、或記錄遠端副本以供 fallback；若 replicas 耗盡，則回退到 fallback 策略，並避免重複節點。【F:policies.go†L724-L879】理解這段邏輯有助於追蹤 token-aware 查詢如何優先選擇本地且健康的節點。
+
+## DCAware 與 RackAware 策略
+`DCAwareRoundRobinPolicy` 讓應用優先使用特定資料中心的節點，並可選擇是否允許跨 DC fallback。初始化時會確認目標資料中心存在於目前拓撲中，避免設定錯誤；挑選節點時則以 round-robin 遍歷本地與（必要時）遠端列表。【F:policies.go†L900-L1007】`RackAwareRoundRobinPolicy` 則在 DC-aware 基礎上，進一步依據機架優先順序分層挑選，適合對機架感知的部署。【F:policies.go†L1009-L1038】在需要多層級優先順序時，可參考 `roundRobbin` 如何逐層回退。【F:policies.go†L960-L1006】 
+
+## TokenAware 擴充選項
+`TokenAwareHostPolicy` 提供多個選項調整行為：`ShuffleReplicas` 決定是否隨機排列 replicas，`AvoidSlowReplicas` 會依節點 in-flight 數量排序，`NonLocalReplicasFallback` 則控制是否在本地副本耗盡後改用遠端 replicas。這些選項透過函式參數注入策略結構，在 `Pick` 中改變排序與 fallback 行為。【F:policies.go†L463-L506】【F:policies.go†L782-L861】當查詢需要與 Scylla tablets 整合時，也可利用 tablets routing 路徑優先選擇特定 host。【F:policies.go†L751-L760】閱讀這些選項可以了解如何在程式碼中組合策略以符合部署需求。

--- a/reading_guides/protocol_and_serialization.md
+++ b/reading_guides/protocol_and_serialization.md
@@ -1,0 +1,19 @@
+# 通訊協定與序列化層
+
+## CQL Frame 結構
+`frame.go` 定義了 CQL 原生協定的版本、方向、frame operation 與旗標常數，例如 `flagValues`、`flagPageSize`、`flagCustomPayload` 等，並提供 `protoVersion` 與 `frameOp` 的輔助函式，用於判斷封包方向、結果型別與序列化時應帶的旗標。【F:frame.go†L63-L191】了解這些常數能幫助閱讀 `Conn.executeQuery` 時如何設定 frame，以及伺服端回應時如何解讀結果種類。
+
+## Framer 與協定擴充
+`framer` 負責讀寫 frame、管理緩衝區與自訂 payload，建立時會根據 compressor 與協定版本決定 header 旗標；若協議支援 Scylla 擴充，還會記錄 LWT bitmask、速率限制錯誤代碼與 tablets routing 旗標，供後續解析回應時使用。【F:frame.go†L360-L449】這層結構與 `Conn.exec`、`Conn.recv` 等方法合作，完成請求/回應的序列化流程。
+
+## 型別系統與 TypeInfo
+`marshal.go` 定義了 `TypeInfo` 介面與多種實作：`NativeType` 用於基本型別、`CollectionType` 對應 map/list/set、`TupleTypeInfo` 與 `UDTTypeInfo` 則描述複合型別。每個型別都實作 `NewWithError` 以建立對應 Go 型別，並提供 `String` 呈現人類可讀名稱；`Type` 常數列出 Cassandra 支援的內建型別編號。【F:marshal.go†L1482-L1700】透過這些結構，driver 能在解析 metadata 時推導欄位型別、並於 Marshaling/Unmarshaling 時做適當轉換。
+
+## Marshal/Unmarshal 行為
+`Marshal` 會依照 `TypeInfo` 與輸入值決定如何序列化，包括處理 `Marshaler` 介面、指標、自訂型別與多種內建對映（字串、整數、浮點、集合、UDT、Tuple、Duration 等）；也詳細說明 `UnsetValue`、`nil`、空 slice 等特別情境的編碼方式。`Unmarshal` 則反向操作，支援自訂 `Unmarshaler`、結構 tag 解析以及 tuple 展開邏輯。【F:marshal.go†L66-L199】【F:marshal.go†L1482-L1700】在閱讀查詢結果轉換流程或自訂型別時，這段程式碼是核心參考。
+
+## 錯誤型別
+`errors.go` 實作了對應 CQL 協定錯誤碼的結構（例如 `RequestErrUnavailable`、`RequestErrReadTimeout`、`RequestErrWriteFailure` 等），每個型別都包含一致性、節點數等診斷資訊，並實作 `Error()` 方法以供上層處理。【F:errors.go†L29-L196】這些型別不僅對應 frame 中的 error code，也提供 RetryPolicy 判斷錯誤性質時使用（例如檢查是否為 `RequestErrUnavailable`）。
+
+## UUID、Duration 等輔助型別
+`cqltypes.go` 定義了 `Duration` 等補充型別，並在 `marshal.go` 中提供對應的序列化支援，使得 driver 能直接與 Cassandra 的 duration、UUID、日期/時間等類型互換。【F:cqltypes.go†L1-L30】【F:marshal.go†L1501-L1700】熟悉這些型別有助於編寫自訂結構與欄位時選擇正確的 Go 代表型別。

--- a/reading_guides/query_execution.md
+++ b/reading_guides/query_execution.md
@@ -1,0 +1,16 @@
+# 查詢與執行流程
+
+## Query 結構與預設值
+`Query` 結構保存語句、參數、一致性、分頁、預設時間戳、觀察者、重試與猜測執行策略等資訊；建立時會從 Session 複製預設值（包含一致性、Tracer、Observer、RetryPolicy、DefaultTimestamp 等），並初始化度量資料結構。【F:session.go†L1077-L1170】呼叫端可以透過 `Consistency`／`SetConsistency`、`CustomPayload`、`Trace`、`Observer`、`PageSize`、`DefaultTimestamp`、`RoutingKey`、`WithContext` 等方法調整行為；同時也能設定 `Idempotent`、`SerialConsistency`、`PageState` 與 `NoSkipMetadata` 來控制重試策略、LWT、手動分頁與 metadata 行為。【F:session.go†L1204-L1510】了解這些欄位能幫助閱讀 `executeQuery` 時判斷每個旗標如何影響 frame 建構。
+
+## 執行流程與 queryExecutor
+`Query.Iter` 會在需要時自動執行查詢並建立迭代器，若啟用自動分頁會在伺服端回傳空頁時持續以新的 paging state 重試。【F:session.go†L1538-L1560】`Session.executeQuery` 負責檢查 Session 是否關閉或尚未就緒，然後委派給 `queryExecutor.executeQuery`，使所有查詢都走統一的重試／猜測執行流程。【F:session.go†L648-L660】`queryExecutor` 會根據 Query 是否指定 HostID 選擇對應的連線池或透過 HostSelectionPolicy 建立 host iterator；若 Query 被標記為非 idempotent 或未啟用 speculative execution，則直接執行一次；否則會在時間間隔後啟動額外嘗試並在任何一次成功時取消其他 goroutine。【F:query_executor.go†L31-L133】理解這段程式碼可掌握 Query 在多節點、多連線環境下的執行順序。
+
+## 重試與猜測執行策略
+RetryPolicy 介面允許根據 Query 嘗試次數與錯誤型別決定是否重試、改用其他節點或直接丟出錯誤；預設的 `SimpleRetryPolicy` 會在非 idempotent 已潛在執行成功時停止，否則改向下一個節點重試，LWT 情境下則偏好在同一節點重試避免 Paxos 爭用。【F:policies.go†L166-L198】SpeculativeExecutionPolicy 介面則控制額外嘗試次數與延遲，預設為 `NonSpeculativeExecution`，也可改用固定間隔的 `SimpleSpeculativeExecution`。【F:policies.go†L1224-L1240】Query 透過 `SetSpeculativeExecutionPolicy`、`RetryPolicy` 與 `Idempotent` 方法調整這些策略，讀程式碼時可對照 `queryExecutor` 如何根據設定啟動 goroutine，理解各種選項的效果。【F:session.go†L1428-L1467】 
+
+## 結果迭代與度量
+`Iter` 封裝查詢結果、欄位 metadata、自動分頁狀態與自訂 payload，提供 `Scanner` 介面以逐列讀取並在遇到錯誤時停止；同時也可取得警告、custom payload、paging state 等資訊。【F:session.go†L1701-L1960】`queryMetrics` 會紀錄嘗試次數與延遲，並在 `Query.attempt`／`Batch.attempt` 呼叫時更新；若掛載 Observer，會傳回各節點的統計資料以利監控。【F:session.go†L984-L1059】【F:session.go†L1315-L1333】閱讀這部分可了解 driver 如何將結果與度量緊密結合。
+
+## 批次操作
+`Batch` 與 `Query` 結構相似，除了維護語句列表外，也支援設定一致性、RetryPolicy、SpeculativeExecutionPolicy、Tracer、Observer、DefaultTimestamp、SerialConsistency 以及自訂 payload，並能判斷是否為 idempotent 或 LWT 批次。【F:session.go†L2004-L2160】【F:session.go†L2135-L2154】`Conn.executeBatch` 對每個語句執行 Prepare／序列化參數，建立 `BATCH` frame 後送出，並在回應中處理 warnings。【F:conn.go†L1703-L1780】若批次查詢需要 routing key，可使用 `Batch.GetRoutingKey` 觸發 metadata 推導，同樣依賴 `metadataDescriber` 快取。【F:session.go†L2278-L2287】閱讀批次路徑有助於理解 driver 如何重用 Query 邏輯並加入額外語句處理。

--- a/reading_guides/scylla_and_extensions.md
+++ b/reading_guides/scylla_and_extensions.md
@@ -1,0 +1,13 @@
+# Scylla 專屬擴充功能
+
+## CQL Protocol Extensions
+Scylla 在 SUPPORTED/STARTUP frame 中交換多種協定擴充：`TABLETS_ROUTING_V1` 用於傳送 tablets 路由資訊、`SCYLLA_RATE_LIMIT_ERROR` 提供速率限制錯誤代碼、`SCYLLA_LWT_ADD_METADATA_MARK` 則在 Prepared Statement metadata 上標記 LWT 狀態。這些擴充都實作 `cqlProtocolExtension` 介面，負責序列化與反序列化；`parseSupported` 也會同步解析 Shard-aware 設定與分區器資訊。【F:scylla.go†L17-L188】`framer` 在建立時會根據協商結果開啟對應功能，例如記錄 tablets routing 狀態、儲存 LWT bitmask 與 rate limit error code，為後續 frame 處理提供旗標。【F:frame.go†L360-L449】
+
+## 連線層對 Scylla 支援
+`Conn` 結構保留 `scyllaSupported` 欄位與 `tabletsRoutingV1` 旗標，透過 `setTabletSupported`／`isTabletSupported` 控制是否啟用 tablets 路由；Session 初始化時會檢查第一條控制連線是否支援此擴充，並將結果寫回 Session 供後續查詢與 metadata 取得使用。【F:conn.go†L218-L238】【F:conn.go†L677-L686】【F:session.go†L307-L334】若 Session 啟用了 tablets routing，`Session.TabletsMetadata` 才會允許取得快取資料，避免在不支援的叢集上誤用。【F:session.go†L689-L700】此外，`Conn.executeQuery` 會在 custom payload 中檢查 `tablets-routing-v1`，解析後寫入 `metadataDescriber` 的 tablets 快取。【F:conn.go†L1557-L1569】【F:metadata_scylla.go†L486-L509】這些步驟顯示 driver 如何在連線層動態啟用 Scylla 特有功能。
+
+## Tablets 與 TokenAware 整合
+啟用 tablets routing 後，`TokenAwareHostPolicy` 會在 `Pick` 時優先使用 tablets metadata 決定 replicas，而非僅依 token ring；若找不到對應 tablets，才回退到傳統 token 演算法，並且可以繼續套用避免慢副本等額外策略。【F:policies.go†L751-L804】【F:policies.go†L820-L879】這使得查詢能直接命中擁有對應 tablet 的主機，提高 Scylla tablet 化叢集的效率。
+
+## CDC 與自訂分區器
+Scylla CDC 使用專屬的 `CDCPartitioner`，`scylla_cdc.go` 定義了對應的 `scyllaCDCPartitioner`，從 CDC partition key 解析 token，並在 debug 模式下驗證版本與格式。`scyllaIsCdcTable` 會檢查 table metadata 是否使用 CDC partitioner，以決定是否應用此雜湊邏輯。【F:scylla_cdc.go†L11-L95】這個分區器可透過 Query 的 `GetCustomPartitioner` 介面被 TokenAware 策略使用，在讀取 CDC log 時仍能正確推導 replicas。


### PR DESCRIPTION
## Summary
- add a reading_guides index that points to module-specific documentation
- write guides covering session lifecycle, connection management, query execution, topology metadata, host policies, scylla extensions, and protocol/serialization layers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d39a71a358832d8112d2189a1b4c49